### PR TITLE
Write error to standard error (`stderr`) stream

### DIFF
--- a/src/GrpcCurl/GrpcCurlApp.cs
+++ b/src/GrpcCurl/GrpcCurlApp.cs
@@ -78,7 +78,7 @@ public class GrpcCurlApp
     {
         var backColor = Console.ForegroundColor;
         Console.ForegroundColor = ConsoleColor.Red;
-        await Console.Out.WriteLineAsync(text);
+        await Console.Error.WriteLineAsync(text);
         Console.ForegroundColor = backColor;
     }
 


### PR DESCRIPTION
This PR fixes the console application such that the error message is written to the standard error stream. Before this PR, if a `grpc-curl` invocation output was redirected to a file, but the invocation failed due to some error then the error would be written to the output file. For example, with issue #12, the following would end with the error being written to the file `desc`:

    ./grpc-curl --describe http://192.168.100.1:9200 SpaceX.API.Device.Device > desc

After this PR, `desc` will be empty, but the error (due to #12) will be written to the terminal (if standard error wasn't redirected as well).