### PR TITLE
Use docopt.net for command-line parsing

### DIFF
--- a/src/GrpcCurl/GrpcCurl.csproj
+++ b/src/GrpcCurl/GrpcCurl.csproj
@@ -24,7 +24,8 @@
     </ResolvedFileToPublish>
 
     <PackageReference Include="Grpc.Net.Client" Version="2.42.0" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
+    <PackageReference Include="docopt.net" Version="0.8.1" />
+    <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GrpcCurl/Program.docopt.txt
+++ b/src/GrpcCurl/Program.docopt.txt
@@ -1,0 +1,19 @@
+grpc-curl {version} - 2022 (c) Copyright Alexandre Mutel
+
+Usage:
+  grpc-curl <address:port> <service/method> [--data=<json_string>]
+            [--http] [--json]
+  grpc-curl describe <address:port> <service>
+  grpc-curl -h | --help
+  grpc-curl --version
+
+Sub-commands:
+  describe    Describe the service or dump all services available.
+
+Options:
+  --version                 Show version information.
+  -h, --help                Show help information.
+  -d, --data=<json_string>  JSON string to send as a message.
+  --http                    Use HTTP instead of HTTPS unless the
+                            protocol is specified directly on the address.
+  --json                    Use JSON naming for input and output.


### PR DESCRIPTION
This PR proposes to replace **McMaster.Extensions.CommandLineUtils** with [**docopt.net**](http://docopt.github.io/docopt.net/) for command-line parsing. The benefits are better performance, simplicity, consistency and strong compile-time guarantees. Here is a breakdown of how:

- The added help text file, `Program.docopt.txt`, is the single source of usage and truth. You can flexibly add more text/commentary to help.
- **docopt.net** will [generate efficient command-line parsing code](https://gist.github.com/atifaziz/a1274a60a21403e391638e3e01e7e5f9#file-programarguments-cs-L89-L259) at build-time (via its C# source generator) and a strong-typed class with [commands, arguments and options as its properties](https://gist.github.com/atifaziz/a1274a60a21403e391638e3e01e7e5f9#file-programarguments-cs-L277-L302) (thus yielding the first two benefits). Based on some casual measurements, the average start-up time (with JIT-ing) is now 30% quicker.
- If the text-based usage changes in an incompatible way then the solution will fail to compile so the chances of the C# source code going out of sync with the help is going to be next to zero.
- The text-based usage is based on [docopt], which is based on conventions that have been used for decades in help messages and man pages for describing a program's interface.
- There is no run-time reflection so the code is AOT-friendly.

## Summary of Changes

- `Program.docopt.txt` ([docopt] convention) contains the program usage.
- Naturally, the **McMaster.Extensions.CommandLineUtils** dependency is removed.
- Use of **McMaster.Extensions.CommandLineUtils** API has been replaced with direct use of properties of the arguments class generated by **docopt.net**.
- The program version, for `--version` support, is embedded at compile-time thanks to **[ThisAssembly.AssemblyInfo]**.
- Removed support for `-?` as an alias for help (though it could be added if strictly desired).
- The usage in the help file has been adjusted to use [docopt] conventions/language/syntax/grammar. The changes were very minimal and read more POSIX-y now.
- The option `--describe` has been changed to the sub-command `describe`.
- The usage has been made clearer about which options & arguments belong to which commands. For example, it is clear now that `describe` is a sub-command and options like `--data` don't apply to it.

The biggest incompatibility this introduces is that `describe` is a sub-command instead of an option, but I hope you'll find that the usage reads clearer for the user and still simple for the program to process.

[docopt]: http://docopt.org/
[ThisAssembly.AssemblyInfo]: https://www.nuget.org/packages/ThisAssembly.AssemblyInfo
